### PR TITLE
Add support for instance parameters

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -153,7 +153,7 @@ def param_union(*parameterizeds, **kwargs):
                 kwargs.popitem()[0]))
     d = dict()
     for o in parameterizeds:
-        for k, p in o.param.params().items():
+        for k in o.param:
             if k != 'name':
                 if k in d and warn:
                     warnings.warn("overwriting parameter {}".format(k))
@@ -366,7 +366,7 @@ class Time(Parameterized):
         if time_type and val is None:
             raise Exception("Please specify a value for the new time_type.")
         if time_type:
-            type_param = self.param.params('time_type')
+            type_param = self.param.objects('current').get('time_type')
             type_param.constant = False
             self.time_type = time_type
             type_param.constant = True

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -957,9 +957,6 @@ class Composite(Parameter):
     attributes.
     """
 
-    # Note: objtype is same as _owner, but objtype left for backwards
-    # compatibility (I think it's used in places to detect composite
-    # parameter)
     __slots__=['attribs','objtype']
 
     def __init__(self,attribs=None,**kw):
@@ -1532,12 +1529,12 @@ class Path(Parameter):
     def _validate(self, val):
         if val is None:
             if not self.allow_None:
-                Parameterized(name="%s.%s"%(self._owner.name,self._attrib_name)).warning('None is not allowed')
+                Parameterized(name="%s.%s"%(self.owner.name,self._attrib_name)).warning('None is not allowed')
         else:
             try:
                 self._resolve(val)
             except IOError as e:
-                Parameterized(name="%s.%s"%(self._owner.name,self._attrib_name)).warning('%s',e.args[0])
+                Parameterized(name="%s.%s"%(self.owner.name,self._attrib_name)).warning('%s',e.args[0])
 
     def __get__(self, obj, objtype):
         """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -27,9 +27,10 @@ import collections
 from .parameterized import Parameterized, Parameter, String, \
      descendents, ParameterizedFunction, ParamOverrides
 
-from .parameterized import depends, output   # noqa: api import
-from .parameterized import logging_level     # noqa: api import
-from .parameterized import shared_parameters # noqa: api import
+from .parameterized import depends, output     # noqa: api import
+from .parameterized import logging_level       # noqa: api import
+from .parameterized import shared_parameters   # noqa: api import
+from .parameterized import instance_descriptor # noqa: api import
 
 from collections import OrderedDict
 
@@ -488,7 +489,7 @@ class Dynamic(Parameter):
         else:
             return self._produce_value(gen)
 
-
+    @instance_descriptor
     def __set__(self,obj,val):
         """
         Call the superclass's set and keep this parameter's
@@ -873,7 +874,6 @@ class Tuple(Parameter):
         if not len(val)==self.length:
             raise ValueError("%s: tuple is not of the correct length (%d instead of %d)." %
                              (self._attrib_name,len(val),self.length))
-
 
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -26,11 +26,8 @@ import collections
 
 from .parameterized import Parameterized, Parameter, String, \
      descendents, ParameterizedFunction, ParamOverrides
-
-from .parameterized import depends, output     # noqa: api import
-from .parameterized import logging_level       # noqa: api import
-from .parameterized import shared_parameters   # noqa: api import
-from .parameterized import instance_descriptor # noqa: api import
+from .parameterized import (depends, output, logging_level, # noqa: api import
+     shared_parameters, instance_descriptor)
 
 from collections import OrderedDict
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -489,6 +489,7 @@ class Dynamic(Parameter):
         else:
             return self._produce_value(gen)
 
+
     @instance_descriptor
     def __set__(self,obj,val):
         """

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -726,18 +726,18 @@ class Number(Dynamic):
             if vmax is not None:
                 if incmax is True:
                     if not val <= vmax:
-                        raise ValueError("Parameter '%s' must be at most %s"%(self._attrib_name,vmax))
+                        raise ValueError("Parameter '%s' must be at most %s"%(self.name,vmax))
                 else:
                     if not val < vmax:
-                        raise ValueError("Parameter '%s' must be less than %s"%(self._attrib_name,vmax))
+                        raise ValueError("Parameter '%s' must be less than %s"%(self.name,vmax))
 
             if vmin is not None:
                 if incmin is True:
                     if not val >= vmin:
-                        raise ValueError("Parameter '%s' must be at least %s"%(self._attrib_name,vmin))
+                        raise ValueError("Parameter '%s' must be at least %s"%(self.name,vmin))
                 else:
                     if not val > vmin:
-                        raise ValueError("Parameter '%s' must be greater than %s"%(self._attrib_name,vmin))
+                        raise ValueError("Parameter '%s' must be greater than %s"%(self.name,vmin))
 
 
 
@@ -753,7 +753,7 @@ class Number(Dynamic):
             return
 
         if not _is_number(val):
-            raise ValueError("Parameter '%s' only takes numeric values"%(self._attrib_name))
+            raise ValueError("Parameter '%s' only takes numeric values"%(self.name))
 
         self._checkBounds(val)
 
@@ -797,7 +797,7 @@ class Integer(Number):
             return
 
         if not isinstance(val,int):
-            raise ValueError("Parameter '%s' must be an integer."%self._attrib_name)
+            raise ValueError("Parameter '%s' must be an integer."%self.name)
 
         self._checkBounds(val)
 
@@ -825,16 +825,16 @@ class Boolean(Parameter):
         if self.allow_None:
             if not isinstance(val,bool) and val is not None:
                 raise ValueError("Boolean '%s' only takes a Boolean value or None."
-                                 %self._attrib_name)
+                                 %self.name)
 
             if val is not True and val is not False and val is not None:
-                raise ValueError("Boolean '%s' must be True, False, or None."%self._attrib_name)
+                raise ValueError("Boolean '%s' must be True, False, or None."%self.name)
         else:
             if not isinstance(val,bool):
-                raise ValueError("Boolean '%s' only takes a Boolean value."%self._attrib_name)
+                raise ValueError("Boolean '%s' only takes a Boolean value."%self.name)
 
             if val is not True and val is not False:
-                raise ValueError("Boolean '%s' must be True or False."%self._attrib_name)
+                raise ValueError("Boolean '%s' must be True or False."%self.name)
         super(Boolean, self)._validate(val)
 
 
@@ -856,7 +856,7 @@ class Tuple(Parameter):
             self.length = len(default)
         elif length is None and default is None:
             raise ValueError("%s: length must be specified if no default is supplied." %
-                             (self._attrib_name))
+                             (self.name))
         else:
             self.length = length
         self._validate(default)
@@ -867,11 +867,11 @@ class Tuple(Parameter):
             return
 
         if not isinstance(val,tuple):
-            raise ValueError("Tuple '%s' only takes a tuple value."%self._attrib_name)
+            raise ValueError("Tuple '%s' only takes a tuple value."%self.name)
 
         if not len(val)==self.length:
             raise ValueError("%s: tuple is not of the correct length (%d instead of %d)." %
-                             (self._attrib_name,len(val),self.length))
+                             (self.name,len(val),self.length))
 
 
 
@@ -884,7 +884,7 @@ class NumericTuple(Tuple):
             for n in val:
                 if not _is_number(n):
                     raise ValueError("%s: tuple element is not numeric: %s." %
-                                     (self._attrib_name,str(n)))
+                                     (self.name,str(n)))
 
 
 
@@ -908,7 +908,7 @@ class Callable(Parameter):
 
     def _validate(self, val):
         if not (self.allow_None and val is None) and (not callable(val)):
-            raise ValueError("Callable '%s' only takes a callable object."%self._attrib_name)
+            raise ValueError("Callable '%s' only takes a callable object."%self.name)
         super(Callable, self)._validate(val)
 
 
@@ -975,7 +975,7 @@ class Composite(Parameter):
             return [getattr(obj,a) for a in self.attribs]
 
     def _validate(self, val):
-        assert len(val) == len(self.attribs),"Compound parameter '%s' got the wrong number of values (needed %d, but got %d)." % (self._attrib_name,len(self.attribs),len(val))
+        assert len(val) == len(self.attribs),"Compound parameter '%s' got the wrong number of values (needed %d, but got %d)." % (self.name,len(self.attribs),len(val))
 
     def _post_setter(self, obj, val):
         if obj is None:
@@ -1082,7 +1082,7 @@ class ObjectSelector(SelectorBase):
             # CEBALERT: can be called before __init__ has called
             # super's __init__, i.e. before attrib_name has been set.
             try:
-                attrib_name = self._attrib_name
+                attrib_name = self.name
             except AttributeError:
                 attrib_name = ""
 
@@ -1177,7 +1177,7 @@ class ClassSelector(SelectorBase):
             if not (isinstance(val,self.class_)) and not (val is None and self.allow_None):
                 raise ValueError(
                     "Parameter '%s' value must be an instance of %s, not '%s'" %
-                    (self._attrib_name, class_name, val))
+                    (self.name, class_name, val))
         else:
             if not (val is None and self.allow_None) and not (issubclass(val,self.class_)):
                 raise ValueError(
@@ -1230,27 +1230,27 @@ class List(Parameter):
             return
 
         if not isinstance(val, list):
-            raise ValueError("List '%s' must be a list."%(self._attrib_name))
+            raise ValueError("List '%s' must be a list."%(self.name))
 
         if self.bounds is not None:
             min_length,max_length = self.bounds
             l=len(val)
             if min_length is not None and max_length is not None:
                 if not (min_length <= l <= max_length):
-                    raise ValueError("%s: list length must be between %s and %s (inclusive)"%(self._attrib_name,min_length,max_length))
+                    raise ValueError("%s: list length must be between %s and %s (inclusive)"%(self.name,min_length,max_length))
             elif min_length is not None:
                 if not min_length <= l:
-                    raise ValueError("%s: list length must be at least %s."%(self._attrib_name,min_length))
+                    raise ValueError("%s: list length must be at least %s."%(self.name,min_length))
             elif max_length is not None:
                 if not l <= max_length:
-                    raise ValueError("%s: list length must be at most %s."%(self._attrib_name,max_length))
+                    raise ValueError("%s: list length must be at most %s."%(self.name,max_length))
 
         self._check_type(val)
 
     def _check_type(self,val):
         if self.class_ is not None:
             for v in val:
-                assert isinstance(v,self.class_),repr(self._attrib_name)+": "+repr(v)+" is not an instance of " + repr(self.class_) + "."
+                assert isinstance(v,self.class_),repr(self.name)+": "+repr(v)+" is not an instance of " + repr(self.class_) + "."
 
 
 
@@ -1266,7 +1266,7 @@ class HookList(List):
 
     def _check_type(self,val):
         for v in val:
-            assert callable(v),repr(self._attrib_name)+": "+repr(v)+" is not callable."
+            assert callable(v),repr(self.name)+": "+repr(v)+" is not callable."
 
 
 
@@ -1529,12 +1529,12 @@ class Path(Parameter):
     def _validate(self, val):
         if val is None:
             if not self.allow_None:
-                Parameterized(name="%s.%s"%(self.owner.name,self._attrib_name)).warning('None is not allowed')
+                Parameterized(name="%s.%s"%(self.owner.name,self.name)).warning('None is not allowed')
         else:
             try:
                 self._resolve(val)
             except IOError as e:
-                Parameterized(name="%s.%s"%(self.owner.name,self._attrib_name)).warning('%s',e.args[0])
+                Parameterized(name="%s.%s"%(self.owner.name,self.name)).warning('%s',e.args[0])
 
     def __get__(self, obj, objtype):
         """
@@ -1693,7 +1693,7 @@ class Date(Number):
             return
 
         if not isinstance(val, dt_types) and not (self.allow_None and val is None):
-            raise ValueError("Date '%s' only takes datetime types."%self._attrib_name)
+            raise ValueError("Date '%s' only takes datetime types."%self.name)
 
         self._checkBounds(val)
 
@@ -1712,10 +1712,10 @@ class Color(Parameter):
         if (self.allow_None and val is None):
             return
         if not isinstance(val, String.basestring):
-            raise ValueError("Color '%s' only takes a string value."%self._attrib_name)
+            raise ValueError("Color '%s' only takes a string value."%self.name)
         if not re.match('^#?(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$', val):
             raise ValueError("Color '%s' only accepts valid RGB hex codes."
-                             % self._attrib_name)
+                             % self.name)
 
 
 
@@ -1787,7 +1787,7 @@ class Range(NumericTuple):
                 too_high = (vmax is not None) and (v > vmax if incmax else v >= vmax)
                 if too_low or too_high:
                     raise ValueError("Parameter '%s' %s bound must be in range %s"
-                                     % (self._attrib_name, bound, self.rangestr()))
+                                     % (self.name, bound, self.rangestr()))
 
 
 class DateRange(Range):
@@ -1803,11 +1803,11 @@ class DateRange(Range):
 
         for n in val:
             if not isinstance(n, dt_types):
-                raise ValueError("DateRange '%s' only takes datetime types: %s"%(self._attrib_name,val))
+                raise ValueError("DateRange '%s' only takes datetime types: %s"%(self.name,val))
 
         start, end = val
         if not end >= start:
-           raise ValueError("DateRange '%s': end date %s is before start date %s."%(self._attrib_name,val[1],val[0]))
+           raise ValueError("DateRange '%s': end date %s is before start date %s."%(self.name,val[1],val[0]))
 
         # Calling super(DateRange, self)._check(val) would also check
         # values are numeric, which is redundant, so just call

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -366,7 +366,7 @@ class Time(Parameterized):
         if time_type and val is None:
             raise Exception("Please specify a value for the new time_type.")
         if time_type:
-            type_param = self.param.objects('current').get('time_type')
+            type_param = self.param.objects('existing').get('time_type')
             type_param.constant = False
             self.time_type = time_type
             type_param.constant = True

--- a/param/ipython.py
+++ b/param/ipython.py
@@ -59,7 +59,7 @@ class ParamPager(object):
         True, parameters are also collected from the super classes.
         """
 
-        params = dict(obj.param.params())
+        params = dict(obj.param.objects('current'))
         if isinstance(obj,type):
             changed = []
             val_dict = dict((k,p.default) for (k,p) in params.items())

--- a/param/ipython.py
+++ b/param/ipython.py
@@ -59,7 +59,7 @@ class ParamPager(object):
         True, parameters are also collected from the super classes.
         """
 
-        params = dict(obj.param.objects('current'))
+        params = dict(obj.param.objects('existing'))
         if isinstance(obj,type):
             changed = []
             val_dict = dict((k,p.default) for (k,p) in params.items())

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -756,7 +756,7 @@ class Parameter(object):
             raise AttributeError('The %s parameter %r has already been '
                                  'assigned a name by the %s class, '
                                  'could not assign new name %r. Parameters '
-                                 'may not be shared by multiple classes, '
+                                 'may not be shared by multiple classes; '
                                  'ensure that you create a new parameter '
                                  'instance for each new class.'
                                  % (type(self).__name__, self.name,

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -777,6 +777,17 @@ class Parameter(object):
 
     def __setstate__(self,state):
         # set values of __slots__ (instead of in non-existent __dict__)
+
+        # Handle renamed slots introduced for instance params
+        if '_attrib_name' in state:
+            state['name'] = state.pop('_attrib_name')
+        if '_owner' in state:
+            state['owner'] = state.pop('_owner')
+        if 'watchers' not in state:
+            state['watchers'] = {}
+        if 'per_instance' not in state:
+            state['per_instance'] = False
+
         for (k,v) in state.items():
             setattr(self,k,v)
 
@@ -2218,13 +2229,19 @@ class Parameterized(object):
 
         return state
 
-    def __setstate__(self,state):
+    def __setstate__(self, state):
         """
         Restore objects from the state dictionary to this object.
 
         During this process the object is considered uninitialized.
         """
         self.initialized=False
+
+        if '_instance__params' not in state:
+            state['_instance__params'] = {}
+        if '_param_watchers' not in state:
+            state['_param_watchers'] = {}
+
         for name,value in state.items():
             setattr(self,name,value)
         self.initialized=True

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1255,7 +1255,9 @@ class Parameters(object):
 
         if instance and self_.self is not None:
             if instance == 'existing':
-                return dict(pdict, **self_.self._instance__params)
+                if self_.self._instance__params:
+                    return dict(pdict, **self_.self._instance__params)
+                return pdict
             else:
                 return {k: self_.self.param[k] for k in pdict}
         return pdict

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1174,16 +1174,19 @@ class Parameters(object):
         Includes Parameters from this class and its
         superclasses.
         """
-        pdict = self_.objects(instance=False)
         if self_.self is not None and self_.self._instance__params:
             self_.warning('The Parameterized instance has instance '
                           'parameters created using new-style param '
                           'APIs, which are incompatible with .params. '
-                          'Either use the new APIs on the .param accessor, '
-                          'i.e. either .param.objects to query all class '
-                          'or instance parameters, or use .param[name] to '
+                          'Use the new more explicit APIs on the '
+                          '.param accessor to query parameter instances.'
+                          'To query all parameter instances use '
+                          '.param.objects with the option to return '
+                          'either class or instance parameter objects. '
+                          'Alternatively use .param[name] indexing to '
                           'access a specific parameter object by name.')
 
+        pdict = self_.objects(instance='existing')
         if parameter_name is None:
             return pdict
         else:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -209,7 +209,7 @@ def accept_arguments(f):
     return _f
 
 
-def disable_instance_params(cls):
+def no_instance_params(cls):
     """
     Disables instance parameters on the class
     """

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -2437,52 +2437,6 @@ class Parameterized(object):
         return self.param.defaults()
 
 
-# CB: seems to work, but conflicts with (hides)
-# Simulation(OptionalSingleton)'s __deepcopy__ method. Guess it's
-# finally time to clean up that inheritance mess...
-
-##     def __deepcopy__(self,memo=None):
-##         # Deepcopy all attributes in __slots__ and __dict__, except
-##         # for attributes which are ObjectSelector parameters (which
-##         # are not copied at all).
-##         #
-##         # Should be equivalent to copy.deepcopy(self), but without copying
-##         # ObjectSelector parameters.
-
-##         if memo is None:
-##             memo = {}
-
-##         class_ = self.__class__
-##         new_instance = class_.__new__(class_)
-
-##         memo[id(self)]=new_instance
-
-##         ## attributes are in __dict__ and __slots__
-##         all_attributes = []
-##         if hasattr(self,'__dict__'):
-##             all_attributes+=self.__dict__.keys()
-##         if hasattr(self,'__slots__'):
-##             all_attributes+=self.__slots__
-##         attributes_to_copy = all_attributes[:]
-
-##         ## remove ObjectSelector parameters from list to be copied
-##         for param_name,param_obj in self.params().items():
-##             internal_param_name = "_%s_param_value"%param_name
-##             # (if param_obj has 'objects' slot, it's assumed to be an ObjectSelector)
-##             if hasattr(param_obj,'objects') and internal_param_name in attributes_to_copy:
-##                 attributes_to_copy.remove(internal_param_name)
-
-##         for attr in all_attributes:
-##             if attr in attributes_to_copy:
-##                 obj = copy.deepcopy(getattr(self,attr),memo)
-##             else:
-##                 obj = getattr(self,attr)
-##             setattr(new_instance,attr,obj)
-
-##         return new_instance
-
-
-
 
 def print_all_param_defaults():
     """Print the default values for all imported Parameters."""
@@ -2495,7 +2449,6 @@ def print_all_param_defaults():
     for c in classes:
         c.print_param_defaults()
     print("_______________________________________________________________________________")
-
 
 
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -589,10 +589,11 @@ class Parameter(object):
         inheritance of Parameter slots (attributes) from the owning-class'
         class hierarchy (see ParameterizedMetaclass).
 
-        per_instance defaults to False and controls whether a new
-        Parameter instance is created for every Parameterized
-        instance. Enabling this will share the same parameter for all
-        instances including all validation attributes.
+        per_instance defaults to True and controls whether a new
+        Parameter instance can be created for every Parameterized
+        instance. If False, all instances of a Parameterized class
+        will share the same parameter object, including all validation
+        attributes.
 
         In rare cases where the default value should not be pickled,
         set pickle_default_value=False (e.g. for file search paths).

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -563,12 +563,8 @@ class Parameter(object):
     # Note: When initially created, a Parameter does not know which
     # Parameterized class owns it, nor does it know its names
     # (attribute name, internal name). Once the owning Parameterized
-    # class is created, owner, name, and _internal name are
+    # class is created, owner, name, and _internal_name are
     # set.
-
-    # TODO regarding name, owner: what if someone re-uses
-    # a parameter object across different classes? we should raise
-    # an error if attrib name,owner already set
 
     def __init__(self,default=None,doc=None,precedence=None,  # pylint: disable-msg=R0913
                  instantiate=False,constant=False,readonly=False,
@@ -752,10 +748,19 @@ class Parameter(object):
 
 
     def __delete__(self,obj):
-        raise TypeError("Cannot delete '%s': Parameters deletion not allowed."%self.name)
+        raise TypeError("Cannot delete '%s': Parameters deletion not allowed." % self.name)
 
 
-    def _set_names(self,attrib_name):
+    def _set_names(self, attrib_name):
+        if None not in (self.owner, self.name) and attrib_name != self.name:
+            raise AttributeError('The %s parameter %r has already been '
+                                 'assigned a name by the %s class, '
+                                 'could not assign new name %r. Parameters '
+                                 'may not be shared by multiple classes, '
+                                 'ensure that you create a new parameter '
+                                 'instance for each new class.'
+                                 % (type(self).__name__, self.name,
+                                    self.owner.name, attrib_name))
         self.name = attrib_name
         self._internal_name = "_%s_param_value"%attrib_name
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -999,7 +999,6 @@ class Parameters(object):
             if not issubclass(class_, Parameterized):
                 continue
             for (k,v) in class_.__dict__.items():
-
                 # (avoid replacing name with the default of None)
                 if isinstance(v,Parameter) and v.instantiate and k!="name":
                     params_to_instantiate[k]=v

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1176,7 +1176,7 @@ class Parameters(object):
                           'APIs, which are incompatible with .params. '
                           'Either use the new APIs on the .param accessor, '
                           'i.e. either .param.objects to query all class '
-                          'or instance parameters or use .param[name] to '
+                          'or instance parameters, or use .param[name] to '
                           'access a specific parameter object by name.')
 
         if parameter_name is None:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -209,6 +209,14 @@ def accept_arguments(f):
     return _f
 
 
+def disable_instance_params(cls):
+    """
+    Disables instance parameters on the class
+    """
+    cls._disable_instance__params = True
+    return cls
+
+
 def instance_descriptor(f):
     # If parameter has an instance Parameter delegate setting
     def _f(self, obj, val):
@@ -939,7 +947,8 @@ class Parameters(object):
         inst = self_.self
         parameters = self_.objects(False) if inst is None else inst.param.objects(False)
         p = parameters[key]
-        if inst is not None and p.per_instance:
+        if (inst is not None and p.per_instance and
+            not getattr(inst, '_disable_instance__params', False)):
             if key not in inst._instance__params:
                 try:
                     # Do not copy watchers on class parameter

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -15,7 +15,7 @@ import random
 from nose.tools import istest, nottest
 
 
-from param.parameterized import ParamOverrides, shared_parameters
+from param.parameterized import ParamOverrides, shared_parameters, no_instance_params
 
 @nottest
 class _SomeRandomNumbers(object):
@@ -35,6 +35,11 @@ class TestPO(param.Parameterized):
 @nottest
 class TestPOValidation(param.Parameterized):
     value = param.Number(default=2, bounds=(0, 4))
+
+@nottest
+@no_instance_params
+class TestPONoInstance(TestPO):
+    pass
 
 @nottest
 class AnotherTestPO(param.Parameterized):
@@ -234,6 +239,11 @@ class TestParameterized(API1TestCase):
     def test_instance_param_getitem_not_per_instance(self):
         test = TestPO()
         assert test.param['notinst'] is TestPO.param['notinst']
+
+
+    def test_instance_param_getitem_no_instance_params(self):
+        test = TestPONoInstance()
+        assert test.param['inst'] is TestPO.param['inst']
 
 
     def test_instance_param_getattr(self):

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -208,7 +208,7 @@ class TestParameterized(API1TestCase):
     def test_instance_param_objects_set_to_current(self):
         inst = TestPO()
         inst_param = inst.param.inst
-        objects = inst.param.objects(instance='current')
+        objects = inst.param.objects(instance='existing')
 
         for p, obj in objects.items():
             if p == 'inst':

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -33,6 +33,10 @@ class TestPO(param.Parameterized):
     dyn = param.Dynamic(default=1)
 
 @nottest
+class TestPOValidation(param.Parameterized):
+    value = param.Number(default=2, bounds=(0, 4))
+
+@nottest
 class AnotherTestPO(param.Parameterized):
     instPO = param.Parameter(default=TestPO(),instantiate=True)
     notinstPO = param.Parameter(default=TestPO(),instantiate=False)
@@ -129,6 +133,22 @@ class TestParameterized(API1TestCase):
         """Check that a class declared abstract actually shows up as abstract."""
         self.assertEqual(TestAbstractPO.abstract,True)
         self.assertEqual(TestPO.abstract,False)
+
+
+    def test_override_class_param_validation(self):
+        test = TestPOValidation()
+        test.param.value.bounds = (0, 3)
+        with self.assertRaises(ValueError):
+            test.value = 4
+        TestPOValidation.value = 4
+
+
+    def test_remove_class_param_validation(self):
+        test = TestPOValidation()
+        test.param.value.bounds = None
+        test.value = 20
+        with self.assertRaises(ValueError):
+            TestPOValidation.value = 10
 
 
     def test_params(self):

--- a/tests/API1/testparameterizedobject.py
+++ b/tests/API1/testparameterizedobject.py
@@ -6,6 +6,7 @@ import param
 import numbergen
 
 from . import API1TestCase
+from .utils import MockLoggingHandler
 
 # CEBALERT: not anything like a complete test of Parameterized!
 
@@ -24,7 +25,7 @@ class _SomeRandomNumbers(object):
 @nottest
 class TestPO(param.Parameterized):
     inst = param.Parameter(default=[1,2,3],instantiate=True)
-    notinst = param.Parameter(default=[1,2,3],instantiate=False)
+    notinst = param.Parameter(default=[1,2,3],instantiate=False, per_instance=False)
     const = param.Parameter(default=1,constant=True)
     ro = param.Parameter(default="Hello",readonly=True)
     ro2 = param.Parameter(default=object(),readonly=True,instantiate=True)
@@ -47,6 +48,14 @@ class TestParamInstantiation(AnotherTestPO):
 @istest
 class TestParameterized(API1TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestParameterized, cls).setUpClass()
+        log = param.parameterized.get_logger()
+        cls.log_handler = MockLoggingHandler(level='DEBUG')
+        log.addHandler(cls.log_handler)
+
+
     def test_constant_parameter(self):
         """Test that you can't set a constant parameter after construction."""
         testpo = TestPO(const=17)
@@ -57,6 +66,7 @@ class TestParameterized(API1TestCase):
         TestPO.const=9
         testpo = TestPO()
         self.assertEqual(testpo.const,9)
+
 
     def test_readonly_parameter(self):
         """Test that you can't set a read-only parameter on construction or as an attribute."""
@@ -76,7 +86,6 @@ class TestParameterized(API1TestCase):
 
         # check that instantiate was ignored for readonly
         self.assertEqual(testpo.param.params()['ro2'].instantiate,False)
-
 
 
     def test_basic_instantiation(self):
@@ -125,7 +134,6 @@ class TestParameterized(API1TestCase):
     def test_params(self):
         """Basic tests of params() method."""
 
-
         # CB: test not so good because it requires changes if params
         # of PO are changed
         assert 'name' in param.Parameterized.param.params()
@@ -138,6 +146,114 @@ class TestParameterized(API1TestCase):
 
         ## check caching
         assert param.Parameterized.param.params() is param.Parameterized().param.params(), "Results of params() should be cached." # just for performance reasons
+
+
+    def test_param_iterator(self):
+        self.assertEqual(set(TestPO.param), {'name', 'inst', 'notinst', 'const', 'dyn', 'ro', 'ro2'})
+
+
+    def test_param_contains(self):
+        for p in ['name', 'inst', 'notinst', 'const', 'dyn', 'ro', 'ro2']:
+            self.assertIn(p, TestPO.param)
+
+
+    def test_class_param_objects(self):
+        objects = TestPO.param.objects()
+
+        self.assertEqual(set(objects), {'name', 'inst', 'notinst', 'const', 'dyn', 'ro', 'ro2'})
+
+        # Check caching
+        assert TestPO.param.objects() is objects
+
+
+    def test_instance_param_objects(self):
+        inst = TestPO()
+        objects = inst.param.objects()
+
+        for p, obj in objects.items():
+            if p == 'notinst':
+                assert obj is TestPO.param[p]
+            else:
+                assert obj is not TestPO.param[p]
+
+
+    def test_instance_param_objects_set_to_false(self):
+        inst = TestPO()
+        objects = inst.param.objects(instance=False)
+
+        for p, obj in objects.items():
+            assert obj is TestPO.param[p]
+
+
+    def test_instance_param_objects_set_to_current(self):
+        inst = TestPO()
+        inst_param = inst.param.inst
+        objects = inst.param.objects(instance='current')
+
+        for p, obj in objects.items():
+            if p == 'inst':
+                assert obj is inst_param
+            else:
+                assert obj is TestPO.param[p]
+
+
+    def test_instance_param_objects_warn_on_params(self):
+        inst = TestPO()
+        inst.param['inst']
+
+        inst.param.params()
+        self.log_handler.assertContains(
+            'WARNING', 'The Parameterized instance has instance parameters')
+
+
+    def test_instance_param_getitem(self):
+        test = TestPO()
+        assert test.param['inst'] is not TestPO.param['inst']
+
+
+    def test_instance_param_getitem_not_per_instance(self):
+        test = TestPO()
+        assert test.param['notinst'] is TestPO.param['notinst']
+
+
+    def test_instance_param_getattr(self):
+        test = TestPO()
+        assert test.param.inst is not TestPO.param.inst
+
+        # Assert no deep copy
+        assert test.param.inst.default is TestPO.param.inst.default
+
+
+    def test_pprint_instance_params(self):
+        # Ensure pprint does not make instance parameter copies
+        test = TestPO()
+        test.pprint()
+        for p, obj in TestPO.param.objects('current').items():
+            assert obj is TestPO.param[p]
+
+
+    def test_set_param_instance_params(self):
+        # Ensure set_param does not make instance parameter copies
+        test = TestPO()
+        test.param.set_param(inst=3)
+        for p, obj in TestPO.param.objects('current').items():
+            assert obj is TestPO.param[p]
+
+
+    def test_get_param_values_instance_params(self):
+        # Ensure get_param_values does not make instance parameter copies
+        test = TestPO()
+        test.param.get_param_values()
+        for p, obj in TestPO.param.objects('current').items():
+            assert obj is TestPO.param[p]
+
+
+    def test_defaults_instance_params(self):
+        # Ensure get_param_values does not make instance parameter copies
+        test = TestPO()
+        test.param.defaults()
+        for p, obj in TestPO.param.objects('current').items():
+            assert obj is TestPO.param[p]
 
 
     def test_state_saving(self):


### PR DESCRIPTION
This PR implements the notion of an instance parameter which can be accessed using a new API. All parameters can in theory become instance parameters (as long as the new ``per_instance`` slot is set to True). The main balance to strike here is that a) we do not want to pay the cost of copying parameters for all instances and b) we do not want users to have to add any special boilerplate to get instance parameters.

The approach I've therefore taken is to only make a copy of a parameter when it is actually needed. This means that all existing param code will never pay the cost of making instance parameters, there's only two situations where the per instance copy is made:

1. When a instance parameter attribute is watched. This is because you do not want events triggered by changes on the class parameter to trigger events on the instance parameter and vice versa.
2. The second situation when a copy is made is when one of the new APIs is used to access the parameter on an instance, e.g. when you access ``instance.param.param_name`` or ``instance.param['param_name']``. This API will make it easy to change the attributes of instance parameters, but the old ``obj.params()``/``obj.param.params()`` method is unaffected by this.

Leaving the old API unaffected will ensure that old param code never pays the costs associated with instance parameters. 

- [x] Add new ``parameterized.param.__getitem__`` and ``parameterized.param.__getattr__`` accessors for parameters
- [x] Modify setters to ensure they use instance parameters for validation
- [x] Ensure that watching instance parameter attributes makes copies
- [x] Add tests