### PR TITLE
Updates to logging system

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -21,11 +21,10 @@ import sys
 import glob
 import re
 import datetime as dt
-import warnings
 import collections
 
 from .parameterized import Parameterized, Parameter, String, \
-     descendents, ParameterizedFunction, ParamOverrides
+     descendents, ParameterizedFunction, ParamOverrides, get_logger
 
 from .parameterized import depends, output   # noqa: api import
 from .parameterized import logging_level     # noqa: api import
@@ -145,7 +144,7 @@ def param_union(*parameterizeds, **kwargs):
         for k, p in o.param.params().items():
             if k != 'name':
                 if k in d and warn:
-                    warnings.warn("overwriting parameter {}".format(k))
+                    get_logger().warning("overwriting parameter {}".format(k))
                 d[k] = getattr(o, k)
     return d
 

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -32,13 +32,13 @@ VERBOSE = INFO - 1
 logging.addLevelName(VERBOSE, "VERBOSE")
 
 # Get the appropriate logging.Logger instance. If `logger` is None, a
-# logger named `"params"` will be instantiated. If `name` is set, a descendant
-# logger with the name ``"params.<name>"`` is returned (or
+# logger named `"param"` will be instantiated. If `name` is set, a descendant
+# logger with the name ``"param.<name>"`` is returned (or
 # ``logger.name + ".<name>"``)
 logger = None
 def get_logger(name=None):
     if logger is None:
-        root_logger = logging.getLogger('params')
+        root_logger = logging.getLogger('param')
         if not root_logger.handlers:
             formatter = logging.Formatter(
                 fmt='%(levelname)s:%(name)s: %(message)s')

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -31,17 +31,27 @@ except:
 VERBOSE = INFO - 1
 logging.addLevelName(VERBOSE, "VERBOSE")
 
-# Logger instance to use for param; if "logger" is set to None, the root logger
-# will be used.
+# Get the appropriate logging.Logger instance. If `logger` is None, a
+# logger named `"params"` will be instantiated. If `name` is set, a descendant
+# logger with the name ``"params.<name>"`` is returned (or
+# ``logger.name + ".<name>"``)
 logger = None
-def get_logger():
+def get_logger(name=None):
     if logger is None:
-        # If it was not configured before, do default initialization
-        if not logging.getLogger().handlers:
-            logging.basicConfig(level=INFO)
-        return logging.getLogger()
+        root_logger = logging.getLogger('params')
+        if not root_logger.handlers:
+            formatter = logging.Formatter(
+                fmt='%(levelname)s:%(name)s: %(message)s')
+            handler = logging.StreamHandler()
+            handler.setFormatter(formatter)
+            root_logger.addHandler(handler)
     else:
-        return logger
+        root_logger = logger
+    if name is None:
+        return root_logger
+    else:
+        return logging.getLogger(root_logger.name + '.' + name)
+
 
 # Indicates whether warnings should be raised as errors, stopping
 # processing.
@@ -934,8 +944,8 @@ class Parameters(object):
             elif cls._disable_stubs is None:
                 pass
             elif cls._disable_stubs is False:
-                get_logger().log(WARNING,
-                                 '%s: Use method %r via param namespace ' % info)
+                get_logger(name=args[0].__class__.__name__).log(WARNING,
+                                 'Use method %r via param namespace ' % fn.__name__)
             return fn(*args, **kwargs)
 
         inner.__doc__= "Inspect .param.%s method for the full docstring"  % fn.__name__
@@ -1439,14 +1449,12 @@ class Parameters(object):
         See python's logging module for details.
         """
         self_or_cls = self_.self_or_cls
-        if get_logger().isEnabledFor(level):
+        if get_logger(name=self_or_cls.name).isEnabledFor(level):
 
             if dbprint_prefix and callable(dbprint_prefix):
-                prefix=dbprint_prefix() # pylint: disable-msg=E1102
-            else:
-                prefix=""
+                msg = dbprint_prefix() + ": " + msg  # pylint: disable-msg=E1102
 
-            get_logger().log(level, '%s%s: '+msg, prefix, self_or_cls.name, *args, **kw)
+            get_logger(name=self_or_cls.name).log(level, msg, *args, **kw)
 
     def print_param_values(self_):
         """Print the values of all this object's Parameters."""


### PR DESCRIPTION
This PR is (finally) in response to discussions in #267. I've made the changes outlined there. More specifically:

1. The root logger is no longer touched. Instead, a logger named "params" is spawned. Then, every parameterized instance, by default, uses the logger "params.\<name\>", where "\<name\>" is the name of the instance.
2. ``_db_print`` does minimal formatting now. Instead it's handled by the ``StreamHandler`` attached to the "params" logger.
3. ``param_union`` no longer uses ``warnings``.

Let me know if anything needs clarification or fixing.

Best,
Sean