### PR TITLE
Added support for multiple outputs

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -249,7 +249,7 @@ def output(func, *output, **kw):
     Parameterized.param.outputs method. By default the output will
     inherit the method name but a custom name can be declared by
     expressing the Parameter type using a keyword argument. Declaring
-    multiple return types is only supported in Python >= 3.6.
+    multiple return types using keywords is only supported in Python >= 3.6.
 
     The simplest declaration simply declares the method returns an
     object without any type guarantees, e.g.:
@@ -296,6 +296,7 @@ def output(func, *output, **kw):
         if (py_major < 3 or (py_major == 3 and py_minor < 6)) and len(kw) > 1:
             raise ValueError('Multiple output declaration using keywords '
                              'only supported in Python >= 3.6.')
+          # (requires keywords to be kept ordered, which was not true in previous versions)
         outputs = [(name, otype, i if len(kw) > 1 else None)
                    for i, (name, otype) in enumerate(kw.items())]
     else:
@@ -1346,7 +1347,7 @@ class Parameters(object):
     def outputs(self_, evaluate=False):
         """
         Returns a mapping between any declared outputs and a tuple
-        of the declared Parameter type, the output method and the
+        of the declared Parameter type, the output method, and the
         index into the output if multiple outputs are returned.
         If evaluate is set to true, returns a dictionary of the output
         values.

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1344,13 +1344,11 @@ class Parameters(object):
         return _params_depended_on(MInfo(cls=self_.cls,inst=self_.self,name=name,method=getattr(self_.self_or_cls,name)))
 
 
-    def outputs(self_, evaluate=False):
+    def outputs(self_):
         """
         Returns a mapping between any declared outputs and a tuple
         of the declared Parameter type, the output method, and the
         index into the output if multiple outputs are returned.
-        If evaluate is set to true, returns a dictionary of the output
-        values.
         """
         outputs = {}
         method_output = {}
@@ -1362,15 +1360,7 @@ class Parameters(object):
             for override, otype, idx in dinfo['outputs']:
                 if override is not None:
                     name = override
-                if evaluate:
-                    if method not in method_output:
-                        method_output[method] = method()
-                    out = method_output[method]
-                    if idx is not None:
-                        out = out[idx]
-                    outputs[name] = out
-                else:
-                    outputs[name] = (otype, method, idx)
+                outputs[name] = (otype, method, idx)
         return outputs
 
     def _spec_to_obj(self_,spec):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -248,7 +248,8 @@ def output(func, *output, **kw):
     of a Parameterized class can be queried using the
     Parameterized.param.outputs method. By default the output will
     inherit the method name but a custom name can be declared by
-    expressing the Parameter type using a keyword argument.
+    expressing the Parameter type using a keyword argument. Declaring
+    multiple return types is only supported in Python >= 3.6.
 
     The simplest declaration simply declares the method returns an
     object without any type guarantees, e.g.:
@@ -265,35 +266,62 @@ def output(func, *output, **kw):
 
       @output(custom_name=param.Number())
 
+    Multiple outputs may be declared using keywords mapping from
+    output name to the type for Python >= 3.6 or using tuples of the
+    same format, which is supported for earlier versions, i.e. these
+    two declarations are equivalent:
+
+      @output(number=param.Number(), string=param.String())
+
+      @output(('number', param.Number()), ('string', param.String()))
+
     output also accepts Python object types which will be upgraded to
     a ClassSelector, e.g.:
 
       @output(int)
     """
     if output:
-        name, otype = None, output[0]
+        outputs = []
+        for i, out in enumerate(output):
+            if isinstance(out, tuple) and len(out) == 2 and isinstance(out[0], str):
+                outputs.append(out+(i,))
+            elif isinstance(out, str):
+                outputs.append((out, Parameter(), i))
+            else:
+                outputs.append((None, out, i))
     elif kw:
-        assert len(kw) <= 1
-        name, otype = list(kw.items())[0]
+        py_major = sys.version_info.major
+        py_minor = sys.version_info.minor
+        if (py_major < 3 or (py_major == 3 and py_minor < 6)) and len(kw) > 1:
+            raise ValueError('Multiple output declaration using keywords '
+                             'only supported in Python >= 3.6.')
+        outputs = [(name, otype, i) for i, (name, otype) in enumerate(kw.items())]
     else:
-        name, otype = func.__name__, Parameter()
+        outputs = [(None, Parameter(), 0)]
 
-    if isinstance(otype, type):
-        if issubclass(otype, Parameter):
-            otype = otype()
-        else:
+    names, processed = [], []
+    for name, otype, i in outputs:
+        if isinstance(otype, type):
+            if issubclass(otype, Parameter):
+                otype = otype()
+            else:
+                from .import ClassSelector
+                otype = ClassSelector(class_=otype)
+        elif isinstance(otype, tuple) and all(isinstance(t, type) for t in otype):
             from .import ClassSelector
             otype = ClassSelector(class_=otype)
-    elif isinstance(otype, tuple) and all(isinstance(t, type) for t in otype):
-        from .import ClassSelector
-        otype = ClassSelector(class_=otype)
+        if not isinstance(otype, Parameter):
+            raise ValueError('output type must be declared with a Parameter class, '
+                             'instance or a Python object type.')
+        processed.append((name, otype, i))
+        names.append(name)
 
-    if not isinstance(otype, Parameter):
-        raise ValueError('output type must be declared with a Parameter class, '
-                         'instance or a Python object type.')
+    if len(set(names)) != len(names):
+        raise ValueError('When declaring multiple outputs each value '
+                         'must be unique.')
 
     _dinfo = getattr(func, '_dinfo', {})
-    _dinfo.update({'output': (name, otype)})
+    _dinfo.update({'outputs': processed})
 
     @wraps(func)
     def _output(*args,**kw):
@@ -1322,12 +1350,12 @@ class Parameters(object):
         for name in dir(self_.self_or_cls):
             method = getattr(self_.self_or_cls, name)
             dinfo = getattr(method, '_dinfo', {})
-            if 'output' not in dinfo:
+            if 'outputs' not in dinfo:
                 continue
-            override, otype = dinfo['output']
-            if override is not None:
-                name = override
-            outputs[name] = (otype, method)
+            for override, otype, idx in dinfo['outputs']:
+                if override is not None:
+                    name = override
+                outputs[name] = (otype, method, idx)
         return outputs
 
     def _spec_to_obj(self_,spec):

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1351,7 +1351,6 @@ class Parameters(object):
         index into the output if multiple outputs are returned.
         """
         outputs = {}
-        method_output = {}
         for name in dir(self_.self_or_cls):
             method = getattr(self_.self_or_cls, name)
             dinfo = getattr(method, '_dinfo', {})

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -17,14 +17,18 @@ class TestParamDepends(API1TestCase):
 
             @param.output()
             def single_output(self):
-                pass
+                return 1
 
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['single_output'])
+
         otype, method, idx = outputs['single_output']
         self.assertIs(type(otype), param.Parameter)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'single_output': 1})
 
     def test_named_kwarg_output(self):
         class P(param.Parameterized):
@@ -35,10 +39,14 @@ class TestParamDepends(API1TestCase):
 
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['value'])
+
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'value': 1})
 
     def test_named_and_typed_arg_output(self):
         class P(param.Parameterized):
@@ -49,10 +57,13 @@ class TestParamDepends(API1TestCase):
 
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['value'])
+
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True), {'value': 1})
 
     def test_named_arg_output(self):
         class P(param.Parameterized):
@@ -63,10 +74,13 @@ class TestParamDepends(API1TestCase):
 
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['value'])
+
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Parameter)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True), {'value': 1})
 
     def test_typed_arg_output(self):
         class P(param.Parameterized):
@@ -77,11 +91,14 @@ class TestParamDepends(API1TestCase):
         
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['single_output'])
+
         otype, method, idx = outputs['single_output']
         self.assertIs(type(otype), param.ClassSelector)
         self.assertIs(otype.class_, int)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True), {'single_output': 1})
 
     def test_multiple_named_kwarg_output(self):
         py_major = sys.version_info.major
@@ -98,6 +115,7 @@ class TestParamDepends(API1TestCase):
 
         outputs = P.param.outputs()
         self.assertEqual(list(outputs), ['value', 'value2'])
+
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
         self.assertIs(method, P.multi_output)
@@ -107,6 +125,9 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.String)
         self.assertIs(method, P.multi_output)
         self.assertEqual(idx, 1)
+
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'value': 1, 'value2': 'string'})
 
     def test_multi_named_and_typed_arg_output(self):
         class P(param.Parameterized):
@@ -127,6 +148,9 @@ class TestParamDepends(API1TestCase):
         self.assertIs(method, P.multi_output)
         self.assertEqual(idx, 1)
 
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'value': 1, 'value2': 'string'})
+
     def test_multi_named_arg_output(self):
         class P(param.Parameterized):
 
@@ -146,6 +170,9 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.Parameter)
         self.assertIs(method, P.multi_output)
         self.assertEqual(idx, 1)
+
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'value': 1, 'value2': 2})
 
     def test_multi_typed_arg_output(self):
         with self.assertRaises(ValueError):
@@ -183,4 +210,7 @@ class TestParamDepends(API1TestCase):
         otype, method, idx = outputs['value3']
         self.assertIs(type(otype), param.Number)
         self.assertIs(method, P.single_output)
-        self.assertEqual(idx, 0)
+        self.assertEqual(idx, None)
+
+        self.assertEqual(P().param.outputs(evaluate=True),
+                         {'value': 1, 'value2': 'string', 'value3': 3.0})

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -28,9 +28,6 @@ class TestParamDepends(API1TestCase):
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'single_output': 1})
-
     def test_named_kwarg_output(self):
         class P(param.Parameterized):
 
@@ -46,9 +43,6 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.Integer)
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
-
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'value': 1})
 
     def test_named_and_typed_arg_output(self):
         class P(param.Parameterized):
@@ -66,8 +60,6 @@ class TestParamDepends(API1TestCase):
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(p.param.outputs(evaluate=True), {'value': 1})
-
     def test_named_arg_output(self):
         class P(param.Parameterized):
 
@@ -83,8 +75,6 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.Parameter)
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
-
-        self.assertEqual(p.param.outputs(evaluate=True), {'value': 1})
 
     def test_typed_arg_output(self):
         class P(param.Parameterized):
@@ -102,8 +92,6 @@ class TestParamDepends(API1TestCase):
         self.assertIs(otype.class_, int)
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
-
-        self.assertEqual(p.param.outputs(evaluate=True), {'single_output': 1})
 
     def test_multiple_named_kwarg_output(self):
         py_major = sys.version_info.major
@@ -132,9 +120,6 @@ class TestParamDepends(API1TestCase):
         self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
 
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'value': 1, 'value2': 'string'})
-
     def test_multi_named_and_typed_arg_output(self):
         class P(param.Parameterized):
 
@@ -154,9 +139,6 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.String)
         self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
-
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'value': 1, 'value2': 'string'})
 
     def test_multi_named_arg_output(self):
         class P(param.Parameterized):
@@ -178,9 +160,6 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.Parameter)
         self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
-
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'value': 1, 'value2': 2})
 
     def test_multi_typed_arg_output(self):
         with self.assertRaises(ValueError):
@@ -220,6 +199,3 @@ class TestParamDepends(API1TestCase):
         self.assertIs(type(otype), param.Number)
         self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
-
-        self.assertEqual(p.param.outputs(evaluate=True),
-                         {'value': 1, 'value2': 'string', 'value3': 3.0})

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -19,15 +19,16 @@ class TestParamDepends(API1TestCase):
             def single_output(self):
                 return 1
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(list(outputs), ['single_output'])
 
         otype, method, idx = outputs['single_output']
         self.assertIs(type(otype), param.Parameter)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'single_output': 1})
 
     def test_named_kwarg_output(self):
@@ -37,15 +38,16 @@ class TestParamDepends(API1TestCase):
             def single_output(self):
                 return 1
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(list(outputs), ['value'])
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'value': 1})
 
     def test_named_and_typed_arg_output(self):
@@ -55,15 +57,16 @@ class TestParamDepends(API1TestCase):
             def single_output(self):
                 return 1
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(list(outputs), ['value'])
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True), {'value': 1})
+        self.assertEqual(p.param.outputs(evaluate=True), {'value': 1})
 
     def test_named_arg_output(self):
         class P(param.Parameterized):
@@ -72,15 +75,16 @@ class TestParamDepends(API1TestCase):
             def single_output(self):
                 return 1
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(list(outputs), ['value'])
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Parameter)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True), {'value': 1})
+        self.assertEqual(p.param.outputs(evaluate=True), {'value': 1})
 
     def test_typed_arg_output(self):
         class P(param.Parameterized):
@@ -88,17 +92,18 @@ class TestParamDepends(API1TestCase):
             @param.output(int)
             def single_output(self):
                 return 1
-        
-        outputs = P.param.outputs()
+
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(list(outputs), ['single_output'])
 
         otype, method, idx = outputs['single_output']
         self.assertIs(type(otype), param.ClassSelector)
         self.assertIs(otype.class_, int)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True), {'single_output': 1})
+        self.assertEqual(p.param.outputs(evaluate=True), {'single_output': 1})
 
     def test_multiple_named_kwarg_output(self):
         py_major = sys.version_info.major
@@ -113,20 +118,21 @@ class TestParamDepends(API1TestCase):
             def multi_output(self):
                 return (1, 'string')
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(set(outputs), {'value', 'value2'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 0)
 
         otype, method, idx = outputs['value2']
         self.assertIs(type(otype), param.String)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'value': 1, 'value2': 'string'})
 
     def test_multi_named_and_typed_arg_output(self):
@@ -136,19 +142,20 @@ class TestParamDepends(API1TestCase):
             def multi_output(self):
                 return (1, 'string')
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(set(outputs), {'value', 'value2'})
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 0)
 
         otype, method, idx = outputs['value2']
         self.assertIs(type(otype), param.String)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'value': 1, 'value2': 'string'})
 
     def test_multi_named_arg_output(self):
@@ -158,20 +165,21 @@ class TestParamDepends(API1TestCase):
             def multi_output(self):
                 return (1, 2)
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(set(outputs), {'value', 'value2'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Parameter)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 0)
 
         otype, method, idx = outputs['value2']
         self.assertIs(type(otype), param.Parameter)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'value': 1, 'value2': 2})
 
     def test_multi_typed_arg_output(self):
@@ -193,24 +201,25 @@ class TestParamDepends(API1TestCase):
             def single_output(self):
                 return 3.0
 
-        outputs = P.param.outputs()
+        p = P()
+        outputs = p.param.outputs()
         self.assertEqual(set(outputs), {'value', 'value2', 'value3'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 0)
 
         otype, method, idx = outputs['value2']
         self.assertIs(type(otype), param.ClassSelector)
         self.assertIs(otype.class_, str)
-        self.assertIs(method, P.multi_output)
+        self.assertEqual(method, p.multi_output)
         self.assertEqual(idx, 1)
 
         otype, method, idx = outputs['value3']
         self.assertIs(type(otype), param.Number)
-        self.assertIs(method, P.single_output)
+        self.assertEqual(method, p.single_output)
         self.assertEqual(idx, None)
 
-        self.assertEqual(P().param.outputs(evaluate=True),
+        self.assertEqual(p.param.outputs(evaluate=True),
                          {'value': 1, 'value2': 'string', 'value3': 3.0})

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -114,7 +114,7 @@ class TestParamDepends(API1TestCase):
                 return (1, 'string')
 
         outputs = P.param.outputs()
-        self.assertEqual(list(outputs), ['value', 'value2'])
+        self.assertEqual(set(outputs), {'value', 'value2'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
@@ -137,7 +137,7 @@ class TestParamDepends(API1TestCase):
                 return (1, 'string')
 
         outputs = P.param.outputs()
-        self.assertEqual(list(outputs), ['value', 'value2'])
+        self.assertEqual(set(outputs), {'value', 'value2'})
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)
         self.assertIs(method, P.multi_output)
@@ -159,7 +159,7 @@ class TestParamDepends(API1TestCase):
                 return (1, 2)
 
         outputs = P.param.outputs()
-        self.assertEqual(list(outputs), ['value', 'value2'])
+        self.assertEqual(set(outputs), {'value', 'value2'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Parameter)

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -194,7 +194,7 @@ class TestParamDepends(API1TestCase):
                 return 3.0
 
         outputs = P.param.outputs()
-        self.assertEqual(list(outputs), ['value', 'value2', 'value3'])
+        self.assertEqual(set(outputs), {'value', 'value2', 'value3'})
 
         otype, method, idx = outputs['value']
         self.assertIs(type(otype), param.Integer)

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -3,8 +3,12 @@ Unit test for param.output.
 """
 import sys
 
+from unittest import SkipTest
+
 import param
+
 from . import API1TestCase
+
 
 class TestParamDepends(API1TestCase):
 
@@ -151,7 +155,7 @@ class TestParamDepends(API1TestCase):
                 def single_output(self):
                     return 1
 
-    def test_multi_named_and_typed_arg_output(self):
+    def test_multi_method_named_and_typed_arg_output(self):
         class P(param.Parameterized):
 
             @param.output(('value', param.Integer), ('value2', str))

--- a/tests/API1/testparamoutput.py
+++ b/tests/API1/testparamoutput.py
@@ -1,0 +1,182 @@
+"""
+Unit test for param.output.
+"""
+import sys
+
+import param
+from . import API1TestCase
+
+class TestParamDepends(API1TestCase):
+
+    def test_simple_output(self):
+        class P(param.Parameterized):
+
+            @param.output()
+            def single_output(self):
+                pass
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['single_output'])
+        otype, method, idx = outputs['single_output']
+        self.assertIs(type(otype), param.Parameter)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)
+
+    def test_named_kwarg_output(self):
+        class P(param.Parameterized):
+
+            @param.output(value=param.Integer)
+            def single_output(self):
+                return 1
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value'])
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Integer)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)
+
+    def test_named_and_typed_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output(('value', param.Integer))
+            def single_output(self):
+                return 1
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value'])
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Integer)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)
+
+    def test_named_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output('value')
+            def single_output(self):
+                return 1
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value'])
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Parameter)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)
+
+    def test_typed_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output(int)
+            def single_output(self):
+                return 1
+        
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['single_output'])
+        otype, method, idx = outputs['single_output']
+        self.assertIs(type(otype), param.ClassSelector)
+        self.assertIs(otype.class_, int)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)
+
+    def test_multiple_named_kwarg_output(self):
+        py_major = sys.version_info.major
+        py_minor = sys.version_info.minor
+        if (py_major < 3 or (py_major == 3 and py_minor < 6)):
+            raise SkipTest('Multiple keyword output declarations only '
+                           'supported in Python >= 3.6, skipping test.')
+
+        class P(param.Parameterized):
+
+            @param.output(value=param.Integer, value2=param.String)
+            def multi_output(self):
+                return (1, 'string')
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value', 'value2'])
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Integer)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 0)
+
+        otype, method, idx = outputs['value2']
+        self.assertIs(type(otype), param.String)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 1)
+
+    def test_multi_named_and_typed_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output(('value', param.Integer), ('value2', param.String))
+            def multi_output(self):
+                return (1, 'string')
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value', 'value2'])
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Integer)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 0)
+
+        otype, method, idx = outputs['value2']
+        self.assertIs(type(otype), param.String)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 1)
+
+    def test_multi_named_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output('value', 'value2')
+            def multi_output(self):
+                return (1, 2)
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value', 'value2'])
+
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Parameter)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 0)
+
+        otype, method, idx = outputs['value2']
+        self.assertIs(type(otype), param.Parameter)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 1)
+
+    def test_multi_typed_arg_output(self):
+        with self.assertRaises(ValueError):
+            class P(param.Parameterized):
+
+                @param.output(int, str)
+                def single_output(self):
+                    return 1
+
+    def test_multi_named_and_typed_arg_output(self):
+        class P(param.Parameterized):
+
+            @param.output(('value', param.Integer), ('value2', str))
+            def multi_output(self):
+                return (1, 'string')
+
+            @param.output(('value3', param.Number))
+            def single_output(self):
+                return 3.0
+
+        outputs = P.param.outputs()
+        self.assertEqual(list(outputs), ['value', 'value2', 'value3'])
+
+        otype, method, idx = outputs['value']
+        self.assertIs(type(otype), param.Integer)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 0)
+
+        otype, method, idx = outputs['value2']
+        self.assertIs(type(otype), param.ClassSelector)
+        self.assertIs(otype.class_, str)
+        self.assertIs(method, P.multi_output)
+        self.assertEqual(idx, 1)
+
+        otype, method, idx = outputs['value3']
+        self.assertIs(type(otype), param.Number)
+        self.assertIs(method, P.single_output)
+        self.assertEqual(idx, 0)


### PR DESCRIPTION
This PR adds support for declaring multiple outputs as the return type of a method. The expectation is that if there are multiple outputs they are expected to be in a tuple. To declare multiple outputs two main formats are supported, either as keywords (only in py>=3.6) or for compatibility with older python versions it also supports tuples:

      @output(number=param.Number(), string=param.String())
      def some_method(self):
          ...

      @output(('number', param.Number()), ('string', param.String()))
      def some_method(self):
          ...

The ``parameterized.param.outputs()`` method returns a dictionary like this:

```python
{'number': (param.Number(), parameterized.some_method, 0),
 'string': (param.String(), parameterized.some_method, 1)} 
```

i.e. a mapping from the output's name to a tuple of the (param_type, method,  index), where the index is the index of the output in the return value of the method.

Additionally this PR adds an ``evaluate`` argument to ``Parameterized.param.outputs`` which evaluates the outputs for you and returns a dictionary of the values. Now that a method might return multiple outputs this avoids the user manually having to check the index of a returned value and unpacking it appropriately.

- [x] Implements https://github.com/pyviz/param/issues/310
- [x] Adds unit tests