### PR TITLE
Added keywords_to_params promotion utility

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -158,26 +158,26 @@ def keywords_to_params(selector, **kwargs):
     params = {}
     for k, v in kwargs.items():
         kws = dict(default=v, constant=True)
-        if isinstance(v, param.Parameter):
+        if isinstance(v, Parameter):
             params[k] = v
         elif isinstance(v, bool):
-            params[k] = param.Boolean(**kws)
+            params[k] = Boolean(**kws)
         elif isinstance(v, int):
-            params[k] = param.Integer(**kws)
+            params[k] = Integer(**kws)
         elif isinstance(v, float):
-            params[k] = param.Number(**kws)
+            params[k] = Number(**kws)
         elif isinstance(v, str):
-            params[k] = param.String(**kws)
+            params[k] = String(**kws)
         elif isinstance(v, dict):
-            params[k] = param.Dict(**kws)
+            params[k] = Dict(**kws)
         elif isinstance(v, tuple):
-            params[k] = param.Tuple(**kws)
+            params[k] = Tuple(**kws)
         elif isinstance(v, list):
-            params[k] = param.List(**kws)
+            params[k] = List(**kws)
         elif isinstance(v, np.ndarray):
-            params[k] = param.Array(**kws)
+            params[k] = Array(**kws)
         else:
-            params[k] = param.Parameter(**kws)
+            params[k] = Parameter(**kws)
 
     return params
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -182,6 +182,19 @@ def keywords_to_params(**kwargs):
     return params
 
 
+def create_parameterized_class(name, params, bases=None):
+    """
+    Dynamically create a parameterized class with the given name and the
+    supplied parameters using the specified bases (if specified).
+    """
+    if bases is None:
+        bases = (Parameterized,)
+    if isinstance(bases, list):
+        bases = tuple(bases)
+    elif not isinstance(bases, tuple):
+        bases = (bases,)
+    return type(name, bases, params)
+
 def _get_min_max_value(min, max, value=None, step=None):
     """Return min, max, value given input values with possible None."""
     # Either min and max need to be given, or value needs to be given

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -185,7 +185,15 @@ def guess_param_types(**kwargs):
         elif isinstance(v, np.ndarray):
             params[k] = Array(**kws)
         else:
-            params[k] = Parameter(**kws)
+            from pandas import DataFrame as pdDFrame
+            from pandas import Series as pdSeries
+
+            if isinstance(v, pdDFrame):
+                params[k] = DataFrame(**kws)
+            elif isinstance(v, pdSeries):
+                params[k] = Series(**kws)
+            else:
+                params[k] = Parameter(**kws)
 
     return params
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -150,7 +150,7 @@ def param_union(*parameterizeds, **kwargs):
     return d
 
 
-def keywords_to_params(selector, **kwargs):
+def keywords_to_params(**kwargs):
     """
     Given a set of keyword literals, promote to the appropriate
     parameter type.

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -161,6 +161,8 @@ def guess_param_types(**kwargs):
         kws = dict(default=v, constant=True)
         if isinstance(v, Parameter):
             params[k] = v
+        elif isinstance(v, dt_types):
+            params[k] = Date(**kws)
         elif isinstance(v, bool):
             params[k] = Boolean(**kws)
         elif isinstance(v, int):
@@ -172,7 +174,12 @@ def guess_param_types(**kwargs):
         elif isinstance(v, dict):
             params[k] = Dict(**kws)
         elif isinstance(v, tuple):
-            params[k] = Tuple(**kws)
+            if all(_is_number(el) for el in v):
+                params[k] = NumericTuple(**kws)
+            elif all(isinstance(el. dt_types) for el in v) and len(v)==2:
+                params[k] = DateRange(**kws)
+            else:
+                params[k] = Tuple(**kws)
         elif isinstance(v, list):
             params[k] = List(**kws)
         elif isinstance(v, np.ndarray):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -201,7 +201,7 @@ def guess_param_types(**kwargs):
 def parameterized_class(name, params, bases=Parameterized):
     """
     Dynamically create a parameterized class with the given name and the
-    supplied parameters using the specified bases (if specified).
+    supplied parameters, inheriting from the specified base(s).
     """
     if not (isinstance(bases, list) or isinstance(bases, tuple)):
           bases=[bases]

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -199,7 +199,7 @@ def create_parameterized_class(name, params, bases=None):
 
 def guess_bounds(params, **overrides):
     """
-    Given a dictionary of parameter instances, return a corresponding
+    Given a dictionary of Parameter instances, return a corresponding
     set of copies with the bounds appropriately set.
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -151,10 +151,10 @@ def param_union(*parameterizeds, **kwargs):
     return d
 
 
-def keywords_to_params(**kwargs):
+def guess_param_types(**kwargs):
     """
     Given a set of keyword literals, promote to the appropriate
-    parameter type.
+    parameter type based on some simple heuristics.
     """
     params = {}
     for k, v in kwargs.items():

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -183,7 +183,7 @@ def keywords_to_params(**kwargs):
     return params
 
 
-def create_parameterized_class(name, params, bases=None):
+def parameterized_class(name, params, bases=None):
     """
     Dynamically create a parameterized class with the given name and the
     supplied parameters using the specified bases (if specified).

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -150,6 +150,38 @@ def param_union(*parameterizeds, **kwargs):
     return d
 
 
+def keywords_to_params(selector, **kwargs):
+    """
+    Given a set of keyword literals, promote to the appropriate
+    parameter type.
+    """
+    params = {}
+    for k, v in kwargs.items():
+        kws = dict(default=v, constant=True)
+        if isinstance(v, param.Parameter):
+            params[k] = v
+        elif isinstance(v, bool):
+            params[k] = param.Boolean(**kws)
+        elif isinstance(v, int):
+            params[k] = param.Integer(**kws)
+        elif isinstance(v, float):
+            params[k] = param.Number(**kws)
+        elif isinstance(v, str):
+            params[k] = param.String(**kws)
+        elif isinstance(v, dict):
+            params[k] = param.Dict(**kws)
+        elif isinstance(v, tuple):
+            params[k] = param.Tuple(**kws)
+        elif isinstance(v, list):
+            params[k] = param.List(**kws)
+        elif isinstance(v, np.ndarray):
+            params[k] = param.Array(**kws)
+        else:
+            params[k] = param.Parameter(**kws)
+
+    return params
+
+
 class Infinity(object):
     """
     An instance of this class represents an infinite value. Unlike

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -32,7 +32,7 @@ from .parameterized import logging_level     # noqa: api import
 from .parameterized import shared_parameters # noqa: api import
 
 from collections import OrderedDict
-
+from numbers import Real
 
 # Determine up-to-date version information, if possible, but with a
 # safe fallback to ensure that this file and parameterized.py are the
@@ -180,6 +180,42 @@ def keywords_to_params(selector, **kwargs):
             params[k] = Parameter(**kws)
 
     return params
+
+
+def _get_min_max_value(min, max, value=None, step=None):
+    """Return min, max, value given input values with possible None."""
+    # Either min and max need to be given, or value needs to be given
+    if value is None:
+        if min is None or max is None:
+            raise ValueError('unable to infer range, value '
+                             'from: ({0}, {1}, {2})'.format(min, max, value))
+        diff = max - min
+        value = min + (diff / 2)
+        # Ensure that value has the same type as diff
+        if not isinstance(value, type(diff)):
+            value = min + (diff // 2)
+    else:  # value is not None
+        if not isinstance(value, Real):
+            raise TypeError('expected a real number, got: %r' % value)
+        # Infer min/max from value
+        if value == 0:
+            # This gives (0, 1) of the correct type
+            vrange = (value, value + 1)
+        elif value > 0:
+            vrange = (-value, 3*value)
+        else:
+            vrange = (3*value, -value)
+        if min is None:
+            min = vrange[0]
+        if max is None:
+            max = vrange[1]
+    if step is not None:
+        # ensure value is on a step
+        tick = int((value - min) / step)
+        value = min + tick * step
+    if not min <= value <= max:
+        raise ValueError('value must be between min and max (min={0}, value={1}, max={2})'.format(min, value, max))
+    return min, max, value
 
 
 class Infinity(object):

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -18,6 +18,7 @@ Parameters and Parameterized classes.
 
 import os.path
 import sys
+import copy
 import glob
 import re
 import datetime as dt
@@ -194,6 +195,24 @@ def create_parameterized_class(name, params, bases=None):
     elif not isinstance(bases, tuple):
         bases = (bases,)
     return type(name, bases, params)
+
+
+def guess_bounds(params):
+    """
+    Given a dictionary of parameter instances, return a corresponding
+    set of copies with the bounds appropriately set.
+    """
+    guessed = {}
+    for name, p in params.items():
+        new_param = copy.copy(p)
+        if isinstance(p, (Integer, Number)):
+            minv, maxv, _ = _get_min_max_value(None, None, value=p.default)
+            new_param.bounds = (minv, maxv)
+            guessed[name] = new_param
+        else:
+            guessed[name] = new_param
+    return guessed
+
 
 def _get_min_max_value(min, max, value=None, step=None):
     """Return min, max, value given input values with possible None."""

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -197,20 +197,24 @@ def create_parameterized_class(name, params, bases=None):
     return type(name, bases, params)
 
 
-def guess_bounds(params):
+def guess_bounds(params, **overrides):
     """
     Given a dictionary of parameter instances, return a corresponding
     set of copies with the bounds appropriately set.
+
+
+    If given a set of override keywords, use those numeric tuple bounds.
     """
     guessed = {}
     for name, p in params.items():
         new_param = copy.copy(p)
         if isinstance(p, (Integer, Number)):
-            minv, maxv, _ = _get_min_max_value(None, None, value=p.default)
+            if name in overrides:
+                minv,maxv = overrides[name]
+            else:
+                minv, maxv, _ = _get_min_max_value(None, None, value=p.default)
             new_param.bounds = (minv, maxv)
-            guessed[name] = new_param
-        else:
-            guessed[name] = new_param
+        guessed[name] = new_param
     return guessed
 
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -183,18 +183,14 @@ def keywords_to_params(**kwargs):
     return params
 
 
-def parameterized_class(name, params, bases=None):
+def parameterized_class(name, params, bases=Parameterized):
     """
     Dynamically create a parameterized class with the given name and the
     supplied parameters using the specified bases (if specified).
     """
-    if bases is None:
-        bases = (Parameterized,)
-    if isinstance(bases, list):
-        bases = tuple(bases)
-    elif not isinstance(bases, tuple):
-        bases = (bases,)
-    return type(name, bases, params)
+    if not (isinstance(bases, list) or isinstance(bases, tuple)):
+          bases=[bases]
+    return type(name, tuple(bases), params)
 
 
 def guess_bounds(params, **overrides):


### PR DESCRIPTION
This PR adds a utility that has cropped up several times and has resulted in some level of code duplication. This has cropped up on some dashboarding projects and is used in the HoloViews [`Streams.define`](https://github.com/pyviz/holoviews/blob/master/holoviews/streams.py#L85) classmethod. It is also relevant to the sort of promotion used to generate widgets in the style of `interact` (e.g panel's `interact` function).

Currently WIP as there are several things to discuss:

* Tuples: These map to `param.Tuple` but if the elements are numeric types this could be mapped to `param.NumericTuple`. Note that numeric 2-tuples can also define the bounds on numeric types but you would need a default value: i.e I don't think you can map numeric 2-tuples to a number parameter including bounds. There is also `param.Range` which is related (maybe for 2-tuples only?)
* Dict and List: These map to `param.Dict` and `param.List` but maybe it is more useful to map these to `Selector` instead. How can you switch between these behaviors? Is a flag appropriate?
* HookList: Could check if a list only contains callable elements?
* Path and Filename: Currently only strings are supported though I note that Python 3 has [explicit path objects](https://docs.python.org/3/library/pathlib.html) which would make this unambiguous.
* Callable, Action: If the object is callable, could maybe make this a final fallback before resorting to `param.Parameter`? How to pick between `Callable` or `Action`?
* ClassSelector: Also a fallback if the value is a `type`?
* Foldername, ListSelector, MultiFileSelector, Magnitude, XYCoordinates: Not thought about how to handle any of these yet. 
* Color: Could try to detect hex strings of the right length but this might be risky?

TODO (i.e shouldn't require much discussion):

* Support the new pandas types `Series` and `DataFrame`.
* Support `Date` from datetimes.
* Support `DateRange` from a 2-tuple of datetimes.



