### PR TITLE
Support batch watch on Parameter attributes

### DIFF
--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -50,6 +50,10 @@ class WatchMethodExample(SimpleWatchSubclass):
     def _set_c(self):
         self.c = self.b*2
 
+    @param.depends('c', watch=True)
+    def _set_d_bounds(self):
+        self.param.d.bounds = (self.c, self.c*2)
+
 
 
 class TestWatch(API1TestCase):
@@ -437,6 +441,15 @@ class TestWatchMethod(API1TestCase):
         obj.a = 4
         self.assertEqual(obj.a, 3)
         self.assertEqual(obj2.a, 3)
+
+    def test_multiple_watcher_dispatch_on_param_attribute(self):
+        obj = WatchMethodExample()
+        accumulator = Accumulator()
+
+        obj.param.watch(accumulator, 'd', 'bounds')
+        obj.c = 2
+        self.assertEqual(obj.param.d.bounds, (2, 4))
+        self.assertEqual(accumulator.call_count(), 1)
 
 
 


### PR DESCRIPTION
Currently batch watching merges all events into a single dictionary by name and matches the watcher to dispatch it to by name. This ignores the fact that there may be multiple events for different attributes of the parameter (e.g. ``value``, ``object``, ``precedence`` etc.) and that each attribute might have different watchers. 

Previously this was not problematic but in recent PRs batching is now used to ensure that events are queued correctly internally which means parameter attribute change events can end up in the batch queue.

This PR ensures that the batch watching code correctly respect the ``what`` argument, which describes which parameter attribute is triggering the event.