### PR TITLE
Added a step slot to param.Parameter

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -756,8 +756,8 @@ class Number(Dynamic):
         self.bounds = bounds
         self.inclusive_bounds = inclusive_bounds
         self._softbounds = softbounds
-        self._validate(default)
         self.step = step
+        self._validate(default)
 
 
     def __get__(self,obj,objtype):
@@ -872,6 +872,9 @@ class Number(Dynamic):
         if not _is_number(val):
             raise ValueError("Parameter '%s' only takes numeric values"%(self.name))
 
+        if self.step is not None and not _is_number(self.step):
+            raise ValueError("Step parameter can only be None or a numeric value")
+
         self._checkBounds(val)
 
 
@@ -922,6 +925,10 @@ class Integer(Number):
 
         if not isinstance(val,int):
             raise ValueError("Parameter '%s' must be an integer."%self.name)
+
+        if self.step is not None and not isinstance(self.step, int):
+            raise ValueError("Step parameter can only be None or an integer value")
+
 
         self._checkBounds(val)
 
@@ -1818,6 +1825,9 @@ class Date(Number):
 
         if not isinstance(val, dt_types) and not (self.allow_None and val is None):
             raise ValueError("Date '%s' only takes datetime types."%self.name)
+
+        if self.step is not None and not isinstance(self.step, dt_types):
+            raise ValueError("Step parameter can only be None or a datetime type")
 
         self._checkBounds(val)
 

--- a/param/__init__.py
+++ b/param/__init__.py
@@ -741,9 +741,10 @@ class Number(Dynamic):
 
     """
 
-    __slots__ = ['bounds','_softbounds','inclusive_bounds','set_hook']
+    __slots__ = ['bounds','_softbounds','inclusive_bounds','set_hook', 'step']
 
-    def __init__(self,default=0.0,bounds=None,softbounds=None,inclusive_bounds=(True,True),**params):
+    def __init__(self,default=0.0,bounds=None,softbounds=None,
+                 inclusive_bounds=(True,True), step=None, **params):
         """
         Initialize this parameter object and store the bounds.
 
@@ -756,6 +757,7 @@ class Number(Dynamic):
         self.inclusive_bounds = inclusive_bounds
         self._softbounds = softbounds
         self._validate(default)
+        self.step = step
 
 
     def __get__(self,obj,objtype):
@@ -896,6 +898,13 @@ class Number(Dynamic):
         else:          u = su
 
         return (l,u)
+
+
+    def __setstate__(self,state):
+        if 'step' not in state:
+            state['step'] = None
+
+        super(Number,self).__setstate__(state)
 
 
 

--- a/tests/API1/testnumberparameter.py
+++ b/tests/API1/testnumberparameter.py
@@ -46,4 +46,4 @@ class TestNumberParameters(API1TestCase):
     def test_step_invalid_type_date_parameter(self):
         exception = "Step parameter can only be None or a datetime type"
         with self.assertRaisesRegexp(ValueError, exception):
-             q = param.Date(dt.datetime(2017,2,27), step=3.2)
+            param.Date(dt.datetime(2017,2,27), step=3.2)

--- a/tests/API1/testnumberparameter.py
+++ b/tests/API1/testnumberparameter.py
@@ -12,26 +12,26 @@ class TestNumberParameters(API1TestCase):
         class Q(param.Parameterized):
             q = param.Number(default=1)
 
-        self.assertEqual(Q.param.params('q').step, None)
+        self.assertEqual(Q.param['q'].step, None)
 
     def test_initialization_with_step_class(self):
         class Q(param.Parameterized):
             q = param.Number(default=1, step=0.5)
 
-        self.assertEqual(Q.param.params('q').step, 0.5)
+        self.assertEqual(Q.param['q'].step, 0.5)
 
     def test_initialization_without_step_instance(self):
         class Q(param.Parameterized):
             q = param.Number(default=1)
 
-        self.assertEqual(Q.param.params('q').step, None)
+        self.assertEqual(Q.param['q'].step, None)
 
     def test_initialization_with_step_instance(self):
         class Q(param.Parameterized):
             q = param.Number(default=1, step=0.5)
 
         qobj = Q()
-        self.assertEqual(qobj.param.params('q').step, 0.5)
+        self.assertEqual(qobj.param['q'].step, 0.5)
 
     def test_step_invalid_type_number_parameter(self):
         exception = "Step parameter can only be None or a numeric value"

--- a/tests/API1/testnumberparameter.py
+++ b/tests/API1/testnumberparameter.py
@@ -1,0 +1,34 @@
+"""
+Unit test for Number parameters and their subclasses.
+"""
+import param
+from . import API1TestCase
+
+
+class TestNumberParameters(API1TestCase):
+
+
+    def test_initialization_without_step_class(self):
+        class Q(param.Parameterized):
+            q = param.Number(default=1)
+
+        self.assertEqual(Q.param.params('q').step, None)
+
+    def test_initialization_with_step_class(self):
+        class Q(param.Parameterized):
+            q = param.Number(default=1, step=0.5)
+
+        self.assertEqual(Q.param.params('q').step, 0.5)
+
+    def test_initialization_without_step_instance(self):
+        class Q(param.Parameterized):
+            q = param.Number(default=1)
+
+        self.assertEqual(Q.param.params('q').step, None)
+
+    def test_initialization_with_step_instance(self):
+        class Q(param.Parameterized):
+            q = param.Number(default=1, step=0.5)
+
+        qobj = Q()
+        self.assertEqual(qobj.param.params('q').step, 0.5)

--- a/tests/API1/testnumberparameter.py
+++ b/tests/API1/testnumberparameter.py
@@ -2,11 +2,11 @@
 Unit test for Number parameters and their subclasses.
 """
 import param
+import datetime as dt
 from . import API1TestCase
 
 
 class TestNumberParameters(API1TestCase):
-
 
     def test_initialization_without_step_class(self):
         class Q(param.Parameterized):
@@ -32,3 +32,18 @@ class TestNumberParameters(API1TestCase):
 
         qobj = Q()
         self.assertEqual(qobj.param.params('q').step, 0.5)
+
+    def test_step_invalid_type_number_parameter(self):
+        exception = "Step parameter can only be None or a numeric value"
+        with self.assertRaisesRegexp(ValueError, exception):
+            param.Number(step='invalid value')
+
+    def test_step_invalid_type_integer_parameter(self):
+        exception = "Step parameter can only be None or an integer value"
+        with self.assertRaisesRegexp(ValueError, exception):
+            param.Integer(step=3.4)
+
+    def test_step_invalid_type_date_parameter(self):
+        exception = "Step parameter can only be None or a datetime type"
+        with self.assertRaisesRegexp(ValueError, exception):
+             q = param.Date(dt.datetime(2017,2,27), step=3.2)


### PR DESCRIPTION

This adds a step slot to `Number` parameters. This will be useful for any library that maps parameters to widgets (e.g panel).

TODO:

- [x] Unit tests
- [x] Validation of the step attribute/slot
