### PR TITLE
Allow param.depends to annotate functions

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -26,7 +26,7 @@ import collections
 
 from .parameterized import (
     Parameterized, Parameter, String, ParameterizedFunction, ParamOverrides,
-    descendents, get_logger, instance_descriptor)
+    descendents, get_logger, instance_descriptor, basestring)
 
 from .parameterized import batch_watch, depends, output   # noqa: api import
 from .parameterized import logging_level     # noqa: api import
@@ -1847,7 +1847,7 @@ class Color(Parameter):
     def _validate(self, val):
         if (self.allow_None and val is None):
             return
-        if not isinstance(val, String.basestring):
+        if not isinstance(val, basestring):
             raise ValueError("Color '%s' only takes a string value."%self.name)
         if not re.match('^#?(([0-9a-fA-F]{2}){3}|([0-9a-fA-F]){3})$', val):
             raise ValueError("Color '%s' only accepts valid RGB hex codes."

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -262,9 +262,9 @@ def ismethod(obj):
     if sys.version_info.major == 2:
         return hasattr(obj, 'im_class')
     else:
-        if '.' in obj.__qualname__:
-            return True
-        return 'self' in inspect.signature(obj).parameters
+        owner = getattr(inspect.getmodule(meth),
+                        meth.__qualname__.split('.<locals>', 1)[0].rsplit('.', 1)[0])
+        return isinstance(owner, type)
 
 
 @accept_arguments

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -27,6 +27,7 @@ try:
 except:
     param_pager = None
 
+basestring = basestring if sys.version_info[0]==2 else str # noqa: it is defined
 
 VERBOSE = INFO - 1
 logging.addLevelName(VERBOSE, "VERBOSE")
@@ -258,15 +259,6 @@ def instance_descriptor(f):
     return _f
 
 
-def ismethod(obj):
-    if sys.version_info.major == 2:
-        return hasattr(obj, 'im_class')
-    else:
-        owner = getattr(inspect.getmodule(meth),
-                        meth.__qualname__.split('.<locals>', 1)[0].rsplit('.', 1)[0])
-        return isinstance(owner, type)
-
-
 @accept_arguments
 def depends(func, *dependencies, **kw):
     """
@@ -283,45 +275,52 @@ def depends(func, *dependencies, **kw):
     # (i.e. "func,*dependencies,watch=False" rather than **kw and the check below)
     watch = kw.pop("watch",False)
 
+    @wraps(func)
     def _depends(*args,**kw):
         return func(*args,**kw)
 
-    if ismethod(func):
-        assert len(kw)==0, "@depends accepts only 'watch' kw"
+    deps = list(dependencies)+list(kw.values())
+    string_specs = False
+    for dep in deps:
+        if isinstance(dep, basestring):
+            string_specs = True
+        elif not isinstance(dep, Parameter):
+            raise ValueError('Reactive functions must have '
+                             'only parameters as dependencies. '
+                             'Found %s type instead.' %
+                             type(dep).__name__)
+        elif not (isinstance(dep.owner, Parameterized) or
+                  (isinstance(dep.owner, ParameterizedMetaclass))):
+            owner = 'None' if dep.owner is None else '%s class' % type(dep.owner).__name__
+            raise ValueError('Reactive functions input parameters '
+                             'must be associated with a Parameterized '
+                             'instance, parameter owner is %s.' % owner)
 
-        # TODO: rename dinfo
-        _dinfo = getattr(func, '_dinfo', {})
-        _dinfo.update({'dependencies': dependencies,
-                       'watch': watch})
+    if len({type(dep) for dep in deps}) > 1:
+        raise ValueError('Dependencies must either be defined as strings '
+                         'referencing parameters on the class defining '
+                         'the decorated method or as parameter instances, '
+                         'mixing of string specs and parameter instances '
+                         'is not supported.')
+    elif string_specs and kw:
+        raise AssertionError('Supplying keywords to the decorated method '
+                             'or function is not supported when referencing '
+                             'parameters by name.')
 
-        # storing here risks it being tricky to find if other libraries
-        # mess around with methods
-        _depends._dinfo = _dinfo
-    elif isinstance(func, FunctionType):
-        deps = list(dependencies)+list(kw.values())
+    if not string_specs and watch:
+        def cb(event):
+            args = (getattr(dep.owner, dep.name) for dep in dependencies)
+            dep_kwargs = {n: getattr(dep.owner, dep.name) for n, dep in kw.items()}
+            return func(*args, **dep_kwargs)
 
         for dep in deps:
-            if not isinstance(dep, Parameter):
-                raise ValueError('Reactive functions must have '
-                                 'only parameters as dependencies. '
-                                 'Found %s type instead.' %
-                                 type(dep).__name__)
-            elif not (isinstance(dep.owner, Parameterized) or
-                      (isinstance(dep.owner, type) and not issubclass(dep.owner, Parameterized))):
-                owner = 'None' if dep.owner is None else '%s class' % type(dep.owner).__name__
-                raise ValueError('Reactive functions input parameters '
-                                 'must be associated with a Parameterized '
-                                 'instance, parameter owner is %s.' % owner)
-        if watch:
-            def cb(event):
-                args = (getattr(d.owner, d.name) for d in dependencies)
-                dep_kwargs = {n: getattr(d.owner, d.name) for n, d in kw}
-                return func(*args, **dep_kwargs)
+            dep.owner.param.watch(cb, dep.name)
 
-            for dep in deps:
-                dep.owner.param.watch(cb, dep.name)
+    _dinfo = getattr(func, '_dinfo', {})
+    _dinfo.update({'dependencies': dependencies,
+                   'kw': kw, 'watch': watch})
 
-        _depends._dinfo = {'dependencies': {'args': dependencies, 'kwargs': kw}}
+    _depends._dinfo = _dinfo
 
     return _depends
 
@@ -899,8 +898,6 @@ class String(Parameter):
 
     __slots__ = ['regex']
 
-    basestring = basestring if sys.version_info[0]==2 else str # noqa: it is defined
-
     def __init__(self, default="", regex=None, allow_None=False, **kwargs):
         super(String, self).__init__(default=default, allow_None=allow_None, **kwargs)
         self.regex = regex
@@ -911,7 +908,7 @@ class String(Parameter):
         if self.allow_None and val is None:
             return
 
-        if not isinstance(val, self.basestring):
+        if not isinstance(val, basestring):
             raise ValueError("String '%s' only takes a string value."%self.name)
 
         if self.regex is not None and re.match(self.regex, val) is None:
@@ -977,7 +974,7 @@ class Comparator(object):
 
     equalities = {
         numbers.Number: operator.eq,
-        String.basestring: operator.eq,
+        basestring: operator.eq,
         bytes: operator.eq,
         type(None): operator.eq
     }

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -294,9 +294,6 @@ def depends(func, *dependencies, **kw):
         _dinfo.update({'dependencies': dependencies,
                        'watch': watch})
 
-        def _depends(*args,**kw):
-            return func(*args,**kw)
-
         # storing here risks it being tricky to find if other libraries
         # mess around with methods
         _depends._dinfo = _dinfo

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -259,7 +259,7 @@ def instance_descriptor(f):
 
 
 def ismethod(obj):
-    if sys.version == 2:
+    if sys.version_info.major == 2:
         return hasattr(obj, 'imclass')
     else:
         if '.' in obj.__qualname__:

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -260,7 +260,7 @@ def instance_descriptor(f):
 
 def ismethod(obj):
     if sys.version_info.major == 2:
-        return hasattr(obj, 'imclass')
+        return hasattr(obj, 'im_class')
     else:
         if '.' in obj.__qualname__:
             return True

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -285,22 +285,22 @@ def depends(func, *dependencies, **kw):
         if isinstance(dep, basestring):
             string_specs = True
         elif not isinstance(dep, Parameter):
-            raise ValueError('Reactive functions must have '
-                             'only parameters as dependencies. '
-                             'Found %s type instead.' %
+            raise ValueError('The depends decorator only accepts string '
+                             'types referencing a parameter or parameter '
+                             'instances, found %s type instead.' %
                              type(dep).__name__)
         elif not (isinstance(dep.owner, Parameterized) or
                   (isinstance(dep.owner, ParameterizedMetaclass))):
             owner = 'None' if dep.owner is None else '%s class' % type(dep.owner).__name__
-            raise ValueError('Reactive functions input parameters '
-                             'must be associated with a Parameterized '
-                             'instance, parameter owner is %s.' % owner)
+            raise ValueError('Parameters supplied to the depends decorator, '
+                             'must be bound to a Parameterized class or '
+                             'instance not %s.' % owner)
 
     if len({type(dep) for dep in deps}) > 1:
         raise ValueError('Dependencies must either be defined as strings '
                          'referencing parameters on the class defining '
-                         'the decorated method or as parameter instances, '
-                         'mixing of string specs and parameter instances '
+                         'the decorated method or as parameter instances. '
+                         'Mixing of string specs and parameter instances '
                          'is not supported.')
     elif string_specs and kw:
         raise AssertionError('Supplying keywords to the decorated method '

--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1622,6 +1622,14 @@ class Parameters(object):
     def _spec_to_obj(self_,spec):
         # TODO: when we decide on spec, this method should be
         # rewritten
+
+        if isinstance(spec, Parameter):
+            inst = spec.owner if isinstance(spec.owner, Parameterized) else None
+            cls = spec.owner if inst is None else type(inst)
+            info = PInfo(inst=inst, cls=cls, name=spec.name,
+                         pobj=spec, what='value')
+            return [info]
+
         assert spec.count(":")<=1
 
         spec = spec.strip()

--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -26,7 +26,14 @@ class TestParamDepends(API1TestCase):
             def nested(self):
                 pass
 
+        class P2(param.Parameterized):
+
+            @param.depends(P.param.a)
+            def external_param(self, a):
+                pass
+
         self.P = P
+        self.P2 = P2
 
     def test_param_depends_instance(self):
         p = self.P()
@@ -70,6 +77,15 @@ class TestParamDepends(API1TestCase):
             info = pinfos[(inst.a, p)]
             self.assertEqual(info.name, p)
             self.assertIs(info.inst, inst.a)
+
+    def test_param_external_param_instance(self):
+        inst = self.P2()
+        pinfos = inst.param.params_depended_on('external_param')
+        pinfo = pinfos[0]
+        self.assertIs(pinfo.cls, self.P)
+        self.assertIs(pinfo.inst, None)
+        self.assertEqual(pinfo.name, 'a')
+        self.assertEqual(pinfo.what, 'value')
 
 
 

--- a/tests/API1/testparamdepends.py
+++ b/tests/API1/testparamdepends.py
@@ -70,3 +70,73 @@ class TestParamDepends(API1TestCase):
             info = pinfos[(inst.a, p)]
             self.assertEqual(info.name, p)
             self.assertIs(info.inst, inst.a)
+
+
+
+class TestParamDependsFunction(API1TestCase):
+
+    def setUp(self):
+        class P(param.Parameterized):
+            a = param.Parameter()
+            b = param.Parameter()
+
+
+        self.P = P
+
+    def test_param_depends_function_instance_params(self):
+        p = self.P()
+
+        @param.depends(p.param.a, c=p.param.b)
+        def function(value, c):
+            pass
+
+        dependencies = {
+            'dependencies': (p.param.a,),
+            'kw': {'c': p.param.b},
+            'watch': False
+        }
+        self.assertEqual(function._dinfo, dependencies)
+
+    def test_param_depends_function_class_params(self):
+        p = self.P
+
+        @param.depends(p.param.a, c=p.param.b)
+        def function(value, c):
+            pass
+
+        dependencies = {
+            'dependencies': (p.param.a,),
+            'kw': {'c': p.param.b},
+            'watch': False
+        }
+        self.assertEqual(function._dinfo, dependencies)
+
+    def test_param_depends_function_instance_params_watch(self):
+        p = self.P(a=1, b=2)
+
+        d = []
+
+        @param.depends(p.param.a, c=p.param.b, watch=True)
+        def function(value, c):
+            d.append(value+c)
+
+        p.a = 2
+        self.assertEqual(d, [4])
+        p.b = 3
+        self.assertEqual(d, [4, 5])
+
+    def test_param_depends_function_class_params_watch(self):
+        p = self.P
+        p.a = 1
+        p.b = 2
+
+        d = []
+
+        @param.depends(p.param.a, c=p.param.b, watch=True)
+        def function(value, c):
+            d.append(value+c)
+
+        p.a = 2
+        self.assertEqual(d, [4])
+        p.b = 3
+        self.assertEqual(d, [4, 5])


### PR DESCRIPTION
This PR extends the `depends` decorator to allow it to decorate regular functions not just methods on Parameterized classes. Unlike the usage with a method the decorator must be given parameter instances associated with a Parameterized object. This makes it very easy to tie a simple function to the state of a Parameterized class, scheduling callbacks, and if used in conjunction with Panel makes a reactive pattern possible without requiring users to write entire classes.

The usage with Panel is the primary motivator here, so let us see some examples. Here is a simple example tying the value of a ``FloatSlider`` to the function: 

![screencast 2019-05-14 12-20-04](https://user-images.githubusercontent.com/1550771/57690762-acc4ab80-7642-11e9-960d-863faf032b46.gif)

Another simple example is this implementation of a plot selector using hvplot:

![reactive_plot](https://user-images.githubusercontent.com/1550771/57691092-8c492100-7643-11e9-891f-04a9e04d6e3a.gif)

The decorator allows defining both regular arguments and keyword arguments to be passed to the function and also supports the ``watch`` keyword to schedule a callback.

- [x] Add tests

