### PR TITLE
 Ensure trigger method doesn't drop events in batched mode

### DIFF
--- a/param/parameterized.py
+++ b/param/parameterized.py
@@ -1383,8 +1383,8 @@ class Parameters(object):
         self_.self_or_cls.param._TRIGGER = True
         self_.set_param(**params)
         self_.self_or_cls.param._TRIGGER = False
-        self_.self_or_cls.param._events = events
-        self_.self_or_cls.param._watchers = watchers
+        self_.self_or_cls.param._events += events
+        self_.self_or_cls.param._watchers += watchers
 
 
     def _update_event_type(self_, watcher, event, triggered):

--- a/tests/API1/testwatch.py
+++ b/tests/API1/testwatch.py
@@ -617,6 +617,21 @@ class TestTrigger(API1TestCase):
         self.assertEqual(args[0].new, 0)
         self.assertEqual(args[0].type, 'triggered')
 
+    def test_simple_trigger_when_batched(self):
+        accumulator = Accumulator()
+        obj = SimpleWatchExample()
+        obj.param.watch(accumulator, ['a'])
+        with param.batch_watch(obj):
+            obj.param.trigger('a')
+        self.assertEqual(accumulator.call_count(), 1)
+
+        args = accumulator.args_for_call(0)
+        self.assertEqual(args[0].name, 'a')
+        self.assertEqual(args[0].old, 0)
+        self.assertEqual(args[0].new, 0)
+        # Note: This is not strictly correct
+        self.assertEqual(args[0].type, 'changed')
+
     def test_simple_trigger_one_param_change(self):
         accumulator = Accumulator()
         obj = SimpleWatchExample()


### PR DESCRIPTION
The events now get emitted but still have the wrong type. The complexity of fixing that is too large now so I've opened #344 for now.

Fixes https://github.com/pyviz/panel/issues/450