### PR TITLE
Import abstract collections from collections.abc where possible

### DIFF
--- a/param/__init__.py
+++ b/param/__init__.py
@@ -54,6 +54,12 @@ try:
 except:
     pass
 
+
+try:
+    import collections.abc as collections_abc
+except ImportError:
+    collections_abc = collections
+
 if sys.version_info[0] >= 3:
     unicode = str
 
@@ -108,9 +114,9 @@ def hashable(x):
     part of the object has changed.  Does not (currently) recursively
     replace mutable subobjects.
     """
-    if isinstance(x, collections.MutableSequence):
+    if isinstance(x, collections_abc.MutableSequence):
         return tuple(x)
-    elif isinstance(x, collections.MutableMapping):
+    elif isinstance(x, collections_abc.MutableMapping):
         return tuple([(k,v) for k,v in x.items()])
     else:
         return x
@@ -1164,7 +1170,7 @@ class ObjectSelector(SelectorBase):
                  compute_default_fn=None,check_on_set=None,allow_None=None,**params):
         if objects is None:
             objects = []
-        if isinstance(objects, collections.Mapping):
+        if isinstance(objects, collections_abc.Mapping):
             self.names = objects
             self.objects = list(objects.values())
         else:


### PR DESCRIPTION
In Python 3.3, abstract collections were moved from the ``collections`` module to the submodule ``collections.abc``. In 3.7, importing abstract collections directly from ``collections`` results in a ``DeprecationWarning``. In python 3.8, ``collections`` will no longer contain abstract base classes.

This PR tries to import and use ``collections.abc``. If it fails (python 2.7), it falls back to ``collections``

I was tired of DeprecationWarnings :D